### PR TITLE
fix various bugs

### DIFF
--- a/client.js
+++ b/client.js
@@ -18,6 +18,8 @@ function Client (opts) {
     parser = jsonstream.parse()
   } else if (opts.style === 'array') {
     parser = jsonstream.parse([true])
+  } else if (opts.style === 'object') {
+    parser = jsonstream.parse(['rows', /./])
   } else {
     throw new Error('Unknown feed style.')
   }
@@ -40,8 +42,11 @@ function httpConnect (opts, u) {
     , c = new Client(opts)
     ;
   r.on('response', function (resp) {
-    if (!resp.statusCode === 200) return c.error(new Error('StatusCode is not 200'))
+    if (!resp.statusCode === 200) return c.emit('error', new Error('StatusCode is not 200'))
     resp.pipe(c)
+  })
+  r.on('error', function(e) {
+    return c.emit('error', e)
   })
   r.end()
   return c
@@ -53,7 +58,7 @@ function httpsConnect (opts, u) {
     , c = new Client(opts)
     ;
   r.on('response', function (resp) {
-    if (!resp.statusCode === 200) return c.error(new Error('StatusCode is not 200'))
+    if (!resp.statusCode === 200) return c.emit('error', new Error('StatusCode is not 200'))
     resp.pipe(c)
   })
   r.end()

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var sleep = require('./server')
   , memstore = require('./memstore')
   ;
 
-module.exports = function (getSequence) { return new sleep.SLEEP(getSequence) }
+module.exports = function (getSequence, options) { return new sleep.SLEEP(getSequence, options) }
 module.exports.memstore = function () {return new memstore.MemoryStore}
 
 module.exports.MemoryStore = memstore.MemoryStore


### PR DESCRIPTION
this pull request:
- adds `object` mode, which is `{"rows": []}` (returning arrays to certain versions of IE exposes a json parsing security vulnerability)
- fixes all modes to work when the database is empty. previous `newline` mode returned `\nundefined` and `array` mode returned `]`
- adds ability to pass in default options for `SLEEPStream` to the `SLEEP` constructor
- emits errors on the sleep client stream (this was broken)
