### PR TITLE
make lodash a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "binary-split": "~0.1.0",
     "stream-combiner": "~0.0.2",
     "extend": "~1.2.1",
-    "lodash.clone": "~2.2.1",
+    "lodash": "~2.2.1",
     "JSONStream": "~0.7.1",
     "once": "~1.3.0"
   },


### PR DESCRIPTION
I tried to checkout dat, and ran npm test, but get 

```
Error: Cannot find module 'lodash'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Volumes/untitled/github/random/dat/node_modules/sleep-ref/memstore.js:1:71)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

Looking at memstore.js it looks like more features of lodash are being used. Just include all of lodash for now.
