### PR TITLE
Clarify that since refers to seq values and not id values

### DIFF
--- a/specs/wire.md
+++ b/specs/wire.md
@@ -13,7 +13,7 @@ A *server* can expose this wire protocol at any number of *endpoints*. The scope
 
 ### Options
 
-* since - seq id to start at, returns everything after that, defaults to the start
+* since - returns entries after the entry with the provided `seq` value, defaults to the start
 * limit - maximum number of changes to return, defaults to unlimited XXX can a server optionally limit this to a maximum?
 * include\_data - if present and false, the wire protocol's data field isn't included
 * style - optional. the feed encoding style, either `newline` or `array`. defaults to `array`.


### PR DESCRIPTION
Minor, but at first read the "seq id" phrase looks ambiguous given entries with `seq` and `id` values.
