### PR TITLE
use pump to error handle streams

### DIFF
--- a/client.js
+++ b/client.js
@@ -9,6 +9,7 @@ var net = require('net')
   , combiner = require('stream-combiner')
   , through = require('through')
   , clone = require('lodash')
+  , pump = require('pump')
   , headers = {'content-type':'application/json'}
   ;
 
@@ -55,7 +56,7 @@ function httpConnect (opts, u) {
     ;
   r.on('response', function (resp) {
     if (!resp.statusCode === 200) return c.emit('error', new Error('StatusCode is not 200'))
-    resp.pipe(c)
+    pump(resp, c)
   })
   r.on('error', function(e) {
     return c.emit('error', e)
@@ -72,7 +73,7 @@ function httpsConnect (opts, u) {
     ;
   r.on('response', function (resp) {
     if (!resp.statusCode === 200) return c.emit('error', new Error('StatusCode is not 200'))
-    resp.pipe(c)
+    pump(resp, c)
   })
   r.end()
   return c
@@ -81,11 +82,11 @@ function httpsConnect (opts, u) {
 function netConnect (opts, u) {
   var socket = net.connect(u.port, u.hostname)
   socket.write(JSON.stringify(opts)+'\r\n')
-  return socket.pipe(jsonParser(opts))
+  return pump(socket, jsonParser(opts))
 }
 
 function tlsConnect (opts, u) {
   var socket = net.connect(u.port, u.hostname, opts.tls || {})
   socket.write(JSON.stringify(opts)+'\r\n')
-  return socket.pipe(jsonParser(opts))
+  return pump(socket, jsonParser(opts))
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "extend": "~1.2.1",
     "lodash": "~2.2.1",
     "once": "~1.3.0",
+    "pump": "^0.3.5",
     "stream-combiner": "~0.0.2",
     "through": "~2.3.4"
   },

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ var qs = require('querystring')
   , concat = require('concat-stream')
   , split = require('binary-split')
   , through = require('through')
+  , pump = require('pump')
   , extend = require('extend')
   ;
 
@@ -134,7 +135,7 @@ SLEEP.prototype.netHandler = function (socket) {
 SLEEP.prototype.handler = function (opts, stream) {
   var self = this
   var sl = new SLEEPStream(extend({}, this.options, opts))
-  self.getSequences(opts).pipe(sl).pipe(stream)
+  pump(self.getSequences(opts), sl, stream)
 }
 
 exports.SLEEP = SLEEP


### PR DESCRIPTION
currently this module doesn't do stream error handling

if a request that fetches a long sleep stream from the server is aborted by the user the sequence stream is currently never closed (since pipe doesn't do that for you anymore).

in this pr i use my pump module that makes sure all streams involved in the pipeline are closed if one of them closes prematurely
